### PR TITLE
Fix undefined local variable or method `retry_max`

### DIFF
--- a/lib/clarion/stores/s3.rb
+++ b/lib/clarion/stores/s3.rb
@@ -30,7 +30,7 @@ module Clarion
             key: authn_s3_key(id),
           ).body.read
         rescue Aws::S3::Errors::NoSuchKey, Aws::S3::Errors::AccessDenied
-          if retry_count < retry_max
+          if retry_count < @retry_max
             sleep @retry_interval
             retry_count += 1
             retry


### PR DESCRIPTION
This PR fix bug for fetching authn resource by using AWS S3 store with retrying.

```
NameError - undefined local variable or method `retry_max' for #<Clarion::Stores::S3:0x000055b9feeb1f28>
Did you mean?  @retry_max:
	/app/vendor/bundle/ruby/2.7.0/bundler/gems/clarion-568eb40a7be4/lib/clarion/stores/s3.rb:33:in `rescue in find_authn'
	/app/vendor/bundle/ruby/2.7.0/bundler/gems/clarion-568eb40a7be4/lib/clarion/stores/s3.rb:27:in `find_authn'
	/app/vendor/bundle/ruby/2.7.0/bundler/gems/clarion-568eb40a7be4/lib/clarion/app.rb:96:in `block in <class:App>'
	/app/vendor/bundle/ruby/2.7.0/gems/sinatra-2.0.8.1/lib/sinatra/base.rb:1636:in `call'
:
```
